### PR TITLE
enable http protocol cache for several endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cheerio": "^1.0.0-rc.2",
     "cors": "^2.8.4",
     "express": "^4.16.4",
+    "express-cache-controller": "^1.1.0",
     "lodash": "^4.17.11",
     "memory-cache": "^0.2.0",
     "node-fetch": "^2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3669,6 +3669,14 @@ expect@^23.6.0:
     jest-message-util "^23.4.0"
     jest-regex-util "^23.3.0"
 
+express-cache-controller@^1.1.0:
+  version "1.1.0"
+  resolved "http://registry.npm.taobao.org/express-cache-controller/download/express-cache-controller-1.1.0.tgz#fa8f02e0ec40374ce552522526b6aab883c76048"
+  integrity sha1-+o8C4OxAN0zlUlIlJraquIPHYEg=
+  dependencies:
+    lodash.isnumber "^3.0.3"
+    on-headers "^1.0.1"
+
 express@^4.16.4:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"
@@ -6185,6 +6193,11 @@ lodash.escaperegexp@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
   integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
 
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "http://registry.npm.taobao.org/lodash.isnumber/download/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
@@ -7367,6 +7380,11 @@ on-finished@~2.3.0:
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
   dependencies:
     ee-first "1.1.1"
+
+on-headers@^1.0.1:
+  version "1.0.2"
+  resolved "http://registry.npm.taobao.org/on-headers/download/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha1-dysK5qqlJcOZ5Imt+tkMQD6zwo8=
 
 once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0, once@~1.4.0:
   version "1.4.0"


### PR DESCRIPTION
`github-trending-api` has already done sever-end cache in leverage of `memory-cache`. However the HTTP Protocol Cache was missing, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control

I introduced the [express-cache-controller](https://github.com/DaMouse404/express-cache-controller) library to do the cache-control work. If you think it's redundant, we can set the `Cache-Control` header manually.

For `/languages` endpoint, I set `maxAge=3600`; for `/repositories` and `/developers` , `maxAge=120`.

120 seconds is really short, But when a user first lookup **all** repos, then lookup **js** repo, and then back to **all** repos again very quickly, the browser won't do a server request. Though I can do client-side cache, that another topic.

