### PR TITLE
Updated Read Me to reflect languages.json file which is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ https://github-trending-api.now.sh/repositories?language=javascript&since=weekly
 
 **Parameters:**
 
-- `language`: **optional**, list trending repositories of certain programming languages, possible values are listed [here](languages.json).
+- `language`: **optional**, list trending repositories of certain programming languages, possible values are listed [here](./languages.json).
 - `since`: **optional**, default to `daily`, possible values: `daily`, `weekly` and `monthly`.
 
 **Response:**

--- a/languages.json
+++ b/languages.json
@@ -1,0 +1,1887 @@
+[
+    {
+        "urlParam": "1c-enterprise",
+        "name": "1C Enterprise"
+    },
+    {
+        "urlParam": "abap",
+        "name": "ABAP"
+    },
+    {
+        "urlParam": "abnf",
+        "name": "ABNF"
+    },
+    {
+        "urlParam": "actionscript",
+        "name": "ActionScript"
+    },
+    {
+        "urlParam": "ada",
+        "name": "Ada"
+    },
+    {
+        "urlParam": "adobe-font-metrics",
+        "name": "Adobe Font Metrics"
+    },
+    {
+        "urlParam": "agda",
+        "name": "Agda"
+    },
+    {
+        "urlParam": "ags-script",
+        "name": "AGS Script"
+    },
+    {
+        "urlParam": "alloy",
+        "name": "Alloy"
+    },
+    {
+        "urlParam": "alpine-abuild",
+        "name": "Alpine Abuild"
+    },
+    {
+        "urlParam": "ampl",
+        "name": "AMPL"
+    },
+    {
+        "urlParam": "angelscript",
+        "name": "AngelScript"
+    },
+    {
+        "urlParam": "ant-build-system",
+        "name": "Ant Build System"
+    },
+    {
+        "urlParam": "antlr",
+        "name": "ANTLR"
+    },
+    {
+        "urlParam": "apacheconf",
+        "name": "ApacheConf"
+    },
+    {
+        "urlParam": "apex",
+        "name": "Apex"
+    },
+    {
+        "urlParam": "api-blueprint",
+        "name": "API Blueprint"
+    },
+    {
+        "urlParam": "apl",
+        "name": "APL"
+    },
+    {
+        "urlParam": "apollo-guidance-computer",
+        "name": "Apollo Guidance Computer"
+    },
+    {
+        "urlParam": "applescript",
+        "name": "AppleScript"
+    },
+    {
+        "urlParam": "arc",
+        "name": "Arc"
+    },
+    {
+        "urlParam": "asciidoc",
+        "name": "AsciiDoc"
+    },
+    {
+        "urlParam": "asn.1",
+        "name": "ASN.1"
+    },
+    {
+        "urlParam": "asp",
+        "name": "ASP"
+    },
+    {
+        "urlParam": "aspectj",
+        "name": "AspectJ"
+    },
+    {
+        "urlParam": "assembly",
+        "name": "Assembly"
+    },
+    {
+        "urlParam": "ats",
+        "name": "ATS"
+    },
+    {
+        "urlParam": "augeas",
+        "name": "Augeas"
+    },
+    {
+        "urlParam": "autohotkey",
+        "name": "AutoHotkey"
+    },
+    {
+        "urlParam": "autoit",
+        "name": "AutoIt"
+    },
+    {
+        "urlParam": "awk",
+        "name": "Awk"
+    },
+    {
+        "urlParam": "ballerina",
+        "name": "Ballerina"
+    },
+    {
+        "urlParam": "batchfile",
+        "name": "Batchfile"
+    },
+    {
+        "urlParam": "befunge",
+        "name": "Befunge"
+    },
+    {
+        "urlParam": "bison",
+        "name": "Bison"
+    },
+    {
+        "urlParam": "bitbake",
+        "name": "BitBake"
+    },
+    {
+        "urlParam": "blade",
+        "name": "Blade"
+    },
+    {
+        "urlParam": "blitzbasic",
+        "name": "BlitzBasic"
+    },
+    {
+        "urlParam": "blitzmax",
+        "name": "BlitzMax"
+    },
+    {
+        "urlParam": "bluespec",
+        "name": "Bluespec"
+    },
+    {
+        "urlParam": "boo",
+        "name": "Boo"
+    },
+    {
+        "urlParam": "brainfuck",
+        "name": "Brainfuck"
+    },
+    {
+        "urlParam": "brightscript",
+        "name": "Brightscript"
+    },
+    {
+        "urlParam": "bro",
+        "name": "Bro"
+    },
+    {
+        "urlParam": "c",
+        "name": "C"
+    },
+    {
+        "urlParam": "c%23",
+        "name": "C#"
+    },
+    {
+        "urlParam": "c++",
+        "name": "C++"
+    },
+    {
+        "urlParam": "c-objdump",
+        "name": "C-ObjDump"
+    },
+    {
+        "urlParam": "c2hs-haskell",
+        "name": "C2hs Haskell"
+    },
+    {
+        "urlParam": "cap'n-proto",
+        "name": "Cap'n Proto"
+    },
+    {
+        "urlParam": "cartocss",
+        "name": "CartoCSS"
+    },
+    {
+        "urlParam": "ceylon",
+        "name": "Ceylon"
+    },
+    {
+        "urlParam": "chapel",
+        "name": "Chapel"
+    },
+    {
+        "urlParam": "charity",
+        "name": "Charity"
+    },
+    {
+        "urlParam": "chuck",
+        "name": "ChucK"
+    },
+    {
+        "urlParam": "cirru",
+        "name": "Cirru"
+    },
+    {
+        "urlParam": "clarion",
+        "name": "Clarion"
+    },
+    {
+        "urlParam": "clean",
+        "name": "Clean"
+    },
+    {
+        "urlParam": "click",
+        "name": "Click"
+    },
+    {
+        "urlParam": "clips",
+        "name": "CLIPS"
+    },
+    {
+        "urlParam": "clojure",
+        "name": "Clojure"
+    },
+    {
+        "urlParam": "closure-templates",
+        "name": "Closure Templates"
+    },
+    {
+        "urlParam": "cmake",
+        "name": "CMake"
+    },
+    {
+        "urlParam": "cobol",
+        "name": "COBOL"
+    },
+    {
+        "urlParam": "coffeescript",
+        "name": "CoffeeScript"
+    },
+    {
+        "urlParam": "coldfusion",
+        "name": "ColdFusion"
+    },
+    {
+        "urlParam": "coldfusion-cfc",
+        "name": "ColdFusion CFC"
+    },
+    {
+        "urlParam": "collada",
+        "name": "COLLADA"
+    },
+    {
+        "urlParam": "common-lisp",
+        "name": "Common Lisp"
+    },
+    {
+        "urlParam": "common-workflow-language",
+        "name": "Common Workflow Language"
+    },
+    {
+        "urlParam": "component-pascal",
+        "name": "Component Pascal"
+    },
+    {
+        "urlParam": "cool",
+        "name": "Cool"
+    },
+    {
+        "urlParam": "coq",
+        "name": "Coq"
+    },
+    {
+        "urlParam": "cpp-objdump",
+        "name": "Cpp-ObjDump"
+    },
+    {
+        "urlParam": "creole",
+        "name": "Creole"
+    },
+    {
+        "urlParam": "crystal",
+        "name": "Crystal"
+    },
+    {
+        "urlParam": "cson",
+        "name": "CSON"
+    },
+    {
+        "urlParam": "csound",
+        "name": "Csound"
+    },
+    {
+        "urlParam": "csound-document",
+        "name": "Csound Document"
+    },
+    {
+        "urlParam": "csound-score",
+        "name": "Csound Score"
+    },
+    {
+        "urlParam": "css",
+        "name": "CSS"
+    },
+    {
+        "urlParam": "csv",
+        "name": "CSV"
+    },
+    {
+        "urlParam": "cuda",
+        "name": "Cuda"
+    },
+    {
+        "urlParam": "cweb",
+        "name": "CWeb"
+    },
+    {
+        "urlParam": "cycript",
+        "name": "Cycript"
+    },
+    {
+        "urlParam": "cython",
+        "name": "Cython"
+    },
+    {
+        "urlParam": "d",
+        "name": "D"
+    },
+    {
+        "urlParam": "d-objdump",
+        "name": "D-ObjDump"
+    },
+    {
+        "urlParam": "darcs-patch",
+        "name": "Darcs Patch"
+    },
+    {
+        "urlParam": "dart",
+        "name": "Dart"
+    },
+    {
+        "urlParam": "dataweave",
+        "name": "DataWeave"
+    },
+    {
+        "urlParam": "desktop",
+        "name": "desktop"
+    },
+    {
+        "urlParam": "diff",
+        "name": "Diff"
+    },
+    {
+        "urlParam": "digital-command-language",
+        "name": "DIGITAL Command Language"
+    },
+    {
+        "urlParam": "dm",
+        "name": "DM"
+    },
+    {
+        "urlParam": "dns-zone",
+        "name": "DNS Zone"
+    },
+    {
+        "urlParam": "dockerfile",
+        "name": "Dockerfile"
+    },
+    {
+        "urlParam": "dogescript",
+        "name": "Dogescript"
+    },
+    {
+        "urlParam": "dtrace",
+        "name": "DTrace"
+    },
+    {
+        "urlParam": "dylan",
+        "name": "Dylan"
+    },
+    {
+        "urlParam": "e",
+        "name": "E"
+    },
+    {
+        "urlParam": "eagle",
+        "name": "Eagle"
+    },
+    {
+        "urlParam": "easybuild",
+        "name": "Easybuild"
+    },
+    {
+        "urlParam": "ebnf",
+        "name": "EBNF"
+    },
+    {
+        "urlParam": "ec",
+        "name": "eC"
+    },
+    {
+        "urlParam": "ecere-projects",
+        "name": "Ecere Projects"
+    },
+    {
+        "urlParam": "ecl",
+        "name": "ECL"
+    },
+    {
+        "urlParam": "eclipse",
+        "name": "ECLiPSe"
+    },
+    {
+        "urlParam": "edje-data-collection",
+        "name": "Edje Data Collection"
+    },
+    {
+        "urlParam": "edn",
+        "name": "edn"
+    },
+    {
+        "urlParam": "eiffel",
+        "name": "Eiffel"
+    },
+    {
+        "urlParam": "ejs",
+        "name": "EJS"
+    },
+    {
+        "urlParam": "elixir",
+        "name": "Elixir"
+    },
+    {
+        "urlParam": "elm",
+        "name": "Elm"
+    },
+    {
+        "urlParam": "emacs-lisp",
+        "name": "Emacs Lisp"
+    },
+    {
+        "urlParam": "emberscript",
+        "name": "EmberScript"
+    },
+    {
+        "urlParam": "eq",
+        "name": "EQ"
+    },
+    {
+        "urlParam": "erlang",
+        "name": "Erlang"
+    },
+    {
+        "urlParam": "f%23",
+        "name": "F#"
+    },
+    {
+        "urlParam": "factor",
+        "name": "Factor"
+    },
+    {
+        "urlParam": "fancy",
+        "name": "Fancy"
+    },
+    {
+        "urlParam": "fantom",
+        "name": "Fantom"
+    },
+    {
+        "urlParam": "filebench-wml",
+        "name": "Filebench WML"
+    },
+    {
+        "urlParam": "filterscript",
+        "name": "Filterscript"
+    },
+    {
+        "urlParam": "fish",
+        "name": "fish"
+    },
+    {
+        "urlParam": "flux",
+        "name": "FLUX"
+    },
+    {
+        "urlParam": "formatted",
+        "name": "Formatted"
+    },
+    {
+        "urlParam": "forth",
+        "name": "Forth"
+    },
+    {
+        "urlParam": "fortran",
+        "name": "Fortran"
+    },
+    {
+        "urlParam": "freemarker",
+        "name": "FreeMarker"
+    },
+    {
+        "urlParam": "frege",
+        "name": "Frege"
+    },
+    {
+        "urlParam": "g-code",
+        "name": "G-code"
+    },
+    {
+        "urlParam": "game-maker-language",
+        "name": "Game Maker Language"
+    },
+    {
+        "urlParam": "gams",
+        "name": "GAMS"
+    },
+    {
+        "urlParam": "gap",
+        "name": "GAP"
+    },
+    {
+        "urlParam": "gcc-machine-description",
+        "name": "GCC Machine Description"
+    },
+    {
+        "urlParam": "gdb",
+        "name": "GDB"
+    },
+    {
+        "urlParam": "gdscript",
+        "name": "GDScript"
+    },
+    {
+        "urlParam": "genie",
+        "name": "Genie"
+    },
+    {
+        "urlParam": "genshi",
+        "name": "Genshi"
+    },
+    {
+        "urlParam": "gentoo-ebuild",
+        "name": "Gentoo Ebuild"
+    },
+    {
+        "urlParam": "gentoo-eclass",
+        "name": "Gentoo Eclass"
+    },
+    {
+        "urlParam": "gerber-image",
+        "name": "Gerber Image"
+    },
+    {
+        "urlParam": "gettext-catalog",
+        "name": "Gettext Catalog"
+    },
+    {
+        "urlParam": "gherkin",
+        "name": "Gherkin"
+    },
+    {
+        "urlParam": "glsl",
+        "name": "GLSL"
+    },
+    {
+        "urlParam": "glyph",
+        "name": "Glyph"
+    },
+    {
+        "urlParam": "gn",
+        "name": "GN"
+    },
+    {
+        "urlParam": "gnuplot",
+        "name": "Gnuplot"
+    },
+    {
+        "urlParam": "go",
+        "name": "Go"
+    },
+    {
+        "urlParam": "golo",
+        "name": "Golo"
+    },
+    {
+        "urlParam": "gosu",
+        "name": "Gosu"
+    },
+    {
+        "urlParam": "grace",
+        "name": "Grace"
+    },
+    {
+        "urlParam": "gradle",
+        "name": "Gradle"
+    },
+    {
+        "urlParam": "grammatical-framework",
+        "name": "Grammatical Framework"
+    },
+    {
+        "urlParam": "graph-modeling-language",
+        "name": "Graph Modeling Language"
+    },
+    {
+        "urlParam": "graphql",
+        "name": "GraphQL"
+    },
+    {
+        "urlParam": "graphviz-(dot)",
+        "name": "Graphviz (DOT)"
+    },
+    {
+        "urlParam": "groovy",
+        "name": "Groovy"
+    },
+    {
+        "urlParam": "groovy-server-pages",
+        "name": "Groovy Server Pages"
+    },
+    {
+        "urlParam": "hack",
+        "name": "Hack"
+    },
+    {
+        "urlParam": "haml",
+        "name": "Haml"
+    },
+    {
+        "urlParam": "handlebars",
+        "name": "Handlebars"
+    },
+    {
+        "urlParam": "harbour",
+        "name": "Harbour"
+    },
+    {
+        "urlParam": "haskell",
+        "name": "Haskell"
+    },
+    {
+        "urlParam": "haxe",
+        "name": "Haxe"
+    },
+    {
+        "urlParam": "hcl",
+        "name": "HCL"
+    },
+    {
+        "urlParam": "hlsl",
+        "name": "HLSL"
+    },
+    {
+        "urlParam": "html",
+        "name": "HTML"
+    },
+    {
+        "urlParam": "html+django",
+        "name": "HTML+Django"
+    },
+    {
+        "urlParam": "html+ecr",
+        "name": "HTML+ECR"
+    },
+    {
+        "urlParam": "html+eex",
+        "name": "HTML+EEX"
+    },
+    {
+        "urlParam": "html+erb",
+        "name": "HTML+ERB"
+    },
+    {
+        "urlParam": "html+php",
+        "name": "HTML+PHP"
+    },
+    {
+        "urlParam": "http",
+        "name": "HTTP"
+    },
+    {
+        "urlParam": "hy",
+        "name": "Hy"
+    },
+    {
+        "urlParam": "hyphy",
+        "name": "HyPhy"
+    },
+    {
+        "urlParam": "idl",
+        "name": "IDL"
+    },
+    {
+        "urlParam": "idris",
+        "name": "Idris"
+    },
+    {
+        "urlParam": "igor-pro",
+        "name": "IGOR Pro"
+    },
+    {
+        "urlParam": "inform-7",
+        "name": "Inform 7"
+    },
+    {
+        "urlParam": "ini",
+        "name": "INI"
+    },
+    {
+        "urlParam": "inno-setup",
+        "name": "Inno Setup"
+    },
+    {
+        "urlParam": "io",
+        "name": "Io"
+    },
+    {
+        "urlParam": "ioke",
+        "name": "Ioke"
+    },
+    {
+        "urlParam": "irc-log",
+        "name": "IRC log"
+    },
+    {
+        "urlParam": "isabelle",
+        "name": "Isabelle"
+    },
+    {
+        "urlParam": "isabelle-root",
+        "name": "Isabelle ROOT"
+    },
+    {
+        "urlParam": "j",
+        "name": "J"
+    },
+    {
+        "urlParam": "jasmin",
+        "name": "Jasmin"
+    },
+    {
+        "urlParam": "java",
+        "name": "Java"
+    },
+    {
+        "urlParam": "java-server-pages",
+        "name": "Java Server Pages"
+    },
+    {
+        "urlParam": "javascript",
+        "name": "JavaScript"
+    },
+    {
+        "urlParam": "jflex",
+        "name": "JFlex"
+    },
+    {
+        "urlParam": "jison",
+        "name": "Jison"
+    },
+    {
+        "urlParam": "jison-lex",
+        "name": "Jison Lex"
+    },
+    {
+        "urlParam": "jolie",
+        "name": "Jolie"
+    },
+    {
+        "urlParam": "json",
+        "name": "JSON"
+    },
+    {
+        "urlParam": "json5",
+        "name": "JSON5"
+    },
+    {
+        "urlParam": "jsoniq",
+        "name": "JSONiq"
+    },
+    {
+        "urlParam": "jsonld",
+        "name": "JSONLD"
+    },
+    {
+        "urlParam": "jsx",
+        "name": "JSX"
+    },
+    {
+        "urlParam": "julia",
+        "name": "Julia"
+    },
+    {
+        "urlParam": "jupyter-notebook",
+        "name": "Jupyter Notebook"
+    },
+    {
+        "urlParam": "kicad-layout",
+        "name": "KiCad Layout"
+    },
+    {
+        "urlParam": "kicad-legacy-layout",
+        "name": "KiCad Legacy Layout"
+    },
+    {
+        "urlParam": "kicad-schematic",
+        "name": "KiCad Schematic"
+    },
+    {
+        "urlParam": "kit",
+        "name": "Kit"
+    },
+    {
+        "urlParam": "kotlin",
+        "name": "Kotlin"
+    },
+    {
+        "urlParam": "krl",
+        "name": "KRL"
+    },
+    {
+        "urlParam": "labview",
+        "name": "LabVIEW"
+    },
+    {
+        "urlParam": "lasso",
+        "name": "Lasso"
+    },
+    {
+        "urlParam": "latte",
+        "name": "Latte"
+    },
+    {
+        "urlParam": "lean",
+        "name": "Lean"
+    },
+    {
+        "urlParam": "less",
+        "name": "Less"
+    },
+    {
+        "urlParam": "lex",
+        "name": "Lex"
+    },
+    {
+        "urlParam": "lfe",
+        "name": "LFE"
+    },
+    {
+        "urlParam": "lilypond",
+        "name": "LilyPond"
+    },
+    {
+        "urlParam": "limbo",
+        "name": "Limbo"
+    },
+    {
+        "urlParam": "linker-script",
+        "name": "Linker Script"
+    },
+    {
+        "urlParam": "linux-kernel-module",
+        "name": "Linux Kernel Module"
+    },
+    {
+        "urlParam": "liquid",
+        "name": "Liquid"
+    },
+    {
+        "urlParam": "literate-agda",
+        "name": "Literate Agda"
+    },
+    {
+        "urlParam": "literate-coffeescript",
+        "name": "Literate CoffeeScript"
+    },
+    {
+        "urlParam": "literate-haskell",
+        "name": "Literate Haskell"
+    },
+    {
+        "urlParam": "livescript",
+        "name": "LiveScript"
+    },
+    {
+        "urlParam": "llvm",
+        "name": "LLVM"
+    },
+    {
+        "urlParam": "logos",
+        "name": "Logos"
+    },
+    {
+        "urlParam": "logtalk",
+        "name": "Logtalk"
+    },
+    {
+        "urlParam": "lolcode",
+        "name": "LOLCODE"
+    },
+    {
+        "urlParam": "lookml",
+        "name": "LookML"
+    },
+    {
+        "urlParam": "loomscript",
+        "name": "LoomScript"
+    },
+    {
+        "urlParam": "lsl",
+        "name": "LSL"
+    },
+    {
+        "urlParam": "lua",
+        "name": "Lua"
+    },
+    {
+        "urlParam": "m",
+        "name": "M"
+    },
+    {
+        "urlParam": "m4",
+        "name": "M4"
+    },
+    {
+        "urlParam": "m4sugar",
+        "name": "M4Sugar"
+    },
+    {
+        "urlParam": "makefile",
+        "name": "Makefile"
+    },
+    {
+        "urlParam": "mako",
+        "name": "Mako"
+    },
+    {
+        "urlParam": "markdown",
+        "name": "Markdown"
+    },
+    {
+        "urlParam": "marko",
+        "name": "Marko"
+    },
+    {
+        "urlParam": "mask",
+        "name": "Mask"
+    },
+    {
+        "urlParam": "mathematica",
+        "name": "Mathematica"
+    },
+    {
+        "urlParam": "matlab",
+        "name": "Matlab"
+    },
+    {
+        "urlParam": "maven-pom",
+        "name": "Maven POM"
+    },
+    {
+        "urlParam": "max",
+        "name": "Max"
+    },
+    {
+        "urlParam": "maxscript",
+        "name": "MAXScript"
+    },
+    {
+        "urlParam": "mediawiki",
+        "name": "MediaWiki"
+    },
+    {
+        "urlParam": "mercury",
+        "name": "Mercury"
+    },
+    {
+        "urlParam": "meson",
+        "name": "Meson"
+    },
+    {
+        "urlParam": "metal",
+        "name": "Metal"
+    },
+    {
+        "urlParam": "minid",
+        "name": "MiniD"
+    },
+    {
+        "urlParam": "mirah",
+        "name": "Mirah"
+    },
+    {
+        "urlParam": "modelica",
+        "name": "Modelica"
+    },
+    {
+        "urlParam": "modula-2",
+        "name": "Modula-2"
+    },
+    {
+        "urlParam": "module-management-system",
+        "name": "Module Management System"
+    },
+    {
+        "urlParam": "monkey",
+        "name": "Monkey"
+    },
+    {
+        "urlParam": "moocode",
+        "name": "Moocode"
+    },
+    {
+        "urlParam": "moonscript",
+        "name": "MoonScript"
+    },
+    {
+        "urlParam": "mql4",
+        "name": "MQL4"
+    },
+    {
+        "urlParam": "mql5",
+        "name": "MQL5"
+    },
+    {
+        "urlParam": "mtml",
+        "name": "MTML"
+    },
+    {
+        "urlParam": "muf",
+        "name": "MUF"
+    },
+    {
+        "urlParam": "mupad",
+        "name": "mupad"
+    },
+    {
+        "urlParam": "myghty",
+        "name": "Myghty"
+    },
+    {
+        "urlParam": "ncl",
+        "name": "NCL"
+    },
+    {
+        "urlParam": "nearley",
+        "name": "Nearley"
+    },
+    {
+        "urlParam": "nemerle",
+        "name": "Nemerle"
+    },
+    {
+        "urlParam": "nesc",
+        "name": "nesC"
+    },
+    {
+        "urlParam": "netlinx",
+        "name": "NetLinx"
+    },
+    {
+        "urlParam": "netlinx+erb",
+        "name": "NetLinx+ERB"
+    },
+    {
+        "urlParam": "netlogo",
+        "name": "NetLogo"
+    },
+    {
+        "urlParam": "newlisp",
+        "name": "NewLisp"
+    },
+    {
+        "urlParam": "nextflow",
+        "name": "Nextflow"
+    },
+    {
+        "urlParam": "nginx",
+        "name": "Nginx"
+    },
+    {
+        "urlParam": "nim",
+        "name": "Nim"
+    },
+    {
+        "urlParam": "ninja",
+        "name": "Ninja"
+    },
+    {
+        "urlParam": "nit",
+        "name": "Nit"
+    },
+    {
+        "urlParam": "nix",
+        "name": "Nix"
+    },
+    {
+        "urlParam": "nl",
+        "name": "NL"
+    },
+    {
+        "urlParam": "nsis",
+        "name": "NSIS"
+    },
+    {
+        "urlParam": "nu",
+        "name": "Nu"
+    },
+    {
+        "urlParam": "numpy",
+        "name": "NumPy"
+    },
+    {
+        "urlParam": "objdump",
+        "name": "ObjDump"
+    },
+    {
+        "urlParam": "objective-c",
+        "name": "Objective-C"
+    },
+    {
+        "urlParam": "objective-c++",
+        "name": "Objective-C++"
+    },
+    {
+        "urlParam": "objective-j",
+        "name": "Objective-J"
+    },
+    {
+        "urlParam": "ocaml",
+        "name": "OCaml"
+    },
+    {
+        "urlParam": "omgrofl",
+        "name": "Omgrofl"
+    },
+    {
+        "urlParam": "ooc",
+        "name": "ooc"
+    },
+    {
+        "urlParam": "opa",
+        "name": "Opa"
+    },
+    {
+        "urlParam": "opal",
+        "name": "Opal"
+    },
+    {
+        "urlParam": "opencl",
+        "name": "OpenCL"
+    },
+    {
+        "urlParam": "openedge-abl",
+        "name": "OpenEdge ABL"
+    },
+    {
+        "urlParam": "openrc-runscript",
+        "name": "OpenRC runscript"
+    },
+    {
+        "urlParam": "openscad",
+        "name": "OpenSCAD"
+    },
+    {
+        "urlParam": "opentype-feature-file",
+        "name": "OpenType Feature File"
+    },
+    {
+        "urlParam": "org",
+        "name": "Org"
+    },
+    {
+        "urlParam": "ox",
+        "name": "Ox"
+    },
+    {
+        "urlParam": "oxygene",
+        "name": "Oxygene"
+    },
+    {
+        "urlParam": "oz",
+        "name": "Oz"
+    },
+    {
+        "urlParam": "p4",
+        "name": "P4"
+    },
+    {
+        "urlParam": "pan",
+        "name": "Pan"
+    },
+    {
+        "urlParam": "papyrus",
+        "name": "Papyrus"
+    },
+    {
+        "urlParam": "parrot",
+        "name": "Parrot"
+    },
+    {
+        "urlParam": "parrot-assembly",
+        "name": "Parrot Assembly"
+    },
+    {
+        "urlParam": "parrot-internal-representation",
+        "name": "Parrot Internal Representation"
+    },
+    {
+        "urlParam": "pascal",
+        "name": "Pascal"
+    },
+    {
+        "urlParam": "pawn",
+        "name": "PAWN"
+    },
+    {
+        "urlParam": "pep8",
+        "name": "Pep8"
+    },
+    {
+        "urlParam": "perl",
+        "name": "Perl"
+    },
+    {
+        "urlParam": "perl-6",
+        "name": "Perl 6"
+    },
+    {
+        "urlParam": "php",
+        "name": "PHP"
+    },
+    {
+        "urlParam": "pic",
+        "name": "Pic"
+    },
+    {
+        "urlParam": "pickle",
+        "name": "Pickle"
+    },
+    {
+        "urlParam": "picolisp",
+        "name": "PicoLisp"
+    },
+    {
+        "urlParam": "piglatin",
+        "name": "PigLatin"
+    },
+    {
+        "urlParam": "pike",
+        "name": "Pike"
+    },
+    {
+        "urlParam": "plpgsql",
+        "name": "PLpgSQL"
+    },
+    {
+        "urlParam": "plsql",
+        "name": "PLSQL"
+    },
+    {
+        "urlParam": "pod",
+        "name": "Pod"
+    },
+    {
+        "urlParam": "pogoscript",
+        "name": "PogoScript"
+    },
+    {
+        "urlParam": "pony",
+        "name": "Pony"
+    },
+    {
+        "urlParam": "postcss",
+        "name": "PostCSS"
+    },
+    {
+        "urlParam": "postscript",
+        "name": "PostScript"
+    },
+    {
+        "urlParam": "pov-ray-sdl",
+        "name": "POV-Ray SDL"
+    },
+    {
+        "urlParam": "powerbuilder",
+        "name": "PowerBuilder"
+    },
+    {
+        "urlParam": "powershell",
+        "name": "PowerShell"
+    },
+    {
+        "urlParam": "processing",
+        "name": "Processing"
+    },
+    {
+        "urlParam": "prolog",
+        "name": "Prolog"
+    },
+    {
+        "urlParam": "propeller-spin",
+        "name": "Propeller Spin"
+    },
+    {
+        "urlParam": "protocol-buffer",
+        "name": "Protocol Buffer"
+    },
+    {
+        "urlParam": "public-key",
+        "name": "Public Key"
+    },
+    {
+        "urlParam": "pug",
+        "name": "Pug"
+    },
+    {
+        "urlParam": "puppet",
+        "name": "Puppet"
+    },
+    {
+        "urlParam": "pure-data",
+        "name": "Pure Data"
+    },
+    {
+        "urlParam": "purebasic",
+        "name": "PureBasic"
+    },
+    {
+        "urlParam": "purescript",
+        "name": "PureScript"
+    },
+    {
+        "urlParam": "python",
+        "name": "Python"
+    },
+    {
+        "urlParam": "python-console",
+        "name": "Python console"
+    },
+    {
+        "urlParam": "python-traceback",
+        "name": "Python traceback"
+    },
+    {
+        "urlParam": "qmake",
+        "name": "QMake"
+    },
+    {
+        "urlParam": "qml",
+        "name": "QML"
+    },
+    {
+        "urlParam": "r",
+        "name": "R"
+    },
+    {
+        "urlParam": "racket",
+        "name": "Racket"
+    },
+    {
+        "urlParam": "ragel",
+        "name": "Ragel"
+    },
+    {
+        "urlParam": "raml",
+        "name": "RAML"
+    },
+    {
+        "urlParam": "rascal",
+        "name": "Rascal"
+    },
+    {
+        "urlParam": "raw-token-data",
+        "name": "Raw token data"
+    },
+    {
+        "urlParam": "rdoc",
+        "name": "RDoc"
+    },
+    {
+        "urlParam": "realbasic",
+        "name": "REALbasic"
+    },
+    {
+        "urlParam": "reason",
+        "name": "Reason"
+    },
+    {
+        "urlParam": "rebol",
+        "name": "Rebol"
+    },
+    {
+        "urlParam": "red",
+        "name": "Red"
+    },
+    {
+        "urlParam": "redcode",
+        "name": "Redcode"
+    },
+    {
+        "urlParam": "regular-expression",
+        "name": "Regular Expression"
+    },
+    {
+        "urlParam": "ren'py",
+        "name": "Ren'Py"
+    },
+    {
+        "urlParam": "renderscript",
+        "name": "RenderScript"
+    },
+    {
+        "urlParam": "restructuredtext",
+        "name": "reStructuredText"
+    },
+    {
+        "urlParam": "rexx",
+        "name": "REXX"
+    },
+    {
+        "urlParam": "rhtml",
+        "name": "RHTML"
+    },
+    {
+        "urlParam": "ring",
+        "name": "Ring"
+    },
+    {
+        "urlParam": "rmarkdown",
+        "name": "RMarkdown"
+    },
+    {
+        "urlParam": "robotframework",
+        "name": "RobotFramework"
+    },
+    {
+        "urlParam": "roff",
+        "name": "Roff"
+    },
+    {
+        "urlParam": "rouge",
+        "name": "Rouge"
+    },
+    {
+        "urlParam": "rpc",
+        "name": "RPC"
+    },
+    {
+        "urlParam": "rpm-spec",
+        "name": "RPM Spec"
+    },
+    {
+        "urlParam": "ruby",
+        "name": "Ruby"
+    },
+    {
+        "urlParam": "runoff",
+        "name": "RUNOFF"
+    },
+    {
+        "urlParam": "rust",
+        "name": "Rust"
+    },
+    {
+        "urlParam": "sage",
+        "name": "Sage"
+    },
+    {
+        "urlParam": "saltstack",
+        "name": "SaltStack"
+    },
+    {
+        "urlParam": "sas",
+        "name": "SAS"
+    },
+    {
+        "urlParam": "sass",
+        "name": "Sass"
+    },
+    {
+        "urlParam": "scala",
+        "name": "Scala"
+    },
+    {
+        "urlParam": "scaml",
+        "name": "Scaml"
+    },
+    {
+        "urlParam": "scheme",
+        "name": "Scheme"
+    },
+    {
+        "urlParam": "scilab",
+        "name": "Scilab"
+    },
+    {
+        "urlParam": "scss",
+        "name": "SCSS"
+    },
+    {
+        "urlParam": "sed",
+        "name": "sed"
+    },
+    {
+        "urlParam": "self",
+        "name": "Self"
+    },
+    {
+        "urlParam": "shaderlab",
+        "name": "ShaderLab"
+    },
+    {
+        "urlParam": "shell",
+        "name": "Shell"
+    },
+    {
+        "urlParam": "shellsession",
+        "name": "ShellSession"
+    },
+    {
+        "urlParam": "shen",
+        "name": "Shen"
+    },
+    {
+        "urlParam": "slash",
+        "name": "Slash"
+    },
+    {
+        "urlParam": "slim",
+        "name": "Slim"
+    },
+    {
+        "urlParam": "smali",
+        "name": "Smali"
+    },
+    {
+        "urlParam": "smalltalk",
+        "name": "Smalltalk"
+    },
+    {
+        "urlParam": "smarty",
+        "name": "Smarty"
+    },
+    {
+        "urlParam": "smt",
+        "name": "SMT"
+    },
+    {
+        "urlParam": "solidity",
+        "name": "Solidity"
+    },
+    {
+        "urlParam": "sourcepawn",
+        "name": "SourcePawn"
+    },
+    {
+        "urlParam": "sparql",
+        "name": "SPARQL"
+    },
+    {
+        "urlParam": "spline-font-database",
+        "name": "Spline Font Database"
+    },
+    {
+        "urlParam": "sqf",
+        "name": "SQF"
+    },
+    {
+        "urlParam": "sql",
+        "name": "SQL"
+    },
+    {
+        "urlParam": "sqlpl",
+        "name": "SQLPL"
+    },
+    {
+        "urlParam": "squirrel",
+        "name": "Squirrel"
+    },
+    {
+        "urlParam": "srecode-template",
+        "name": "SRecode Template"
+    },
+    {
+        "urlParam": "stan",
+        "name": "Stan"
+    },
+    {
+        "urlParam": "standard-ml",
+        "name": "Standard ML"
+    },
+    {
+        "urlParam": "stata",
+        "name": "Stata"
+    },
+    {
+        "urlParam": "ston",
+        "name": "STON"
+    },
+    {
+        "urlParam": "stylus",
+        "name": "Stylus"
+    },
+    {
+        "urlParam": "sublime-text-config",
+        "name": "Sublime Text Config"
+    },
+    {
+        "urlParam": "subrip-text",
+        "name": "SubRip Text"
+    },
+    {
+        "urlParam": "sugarss",
+        "name": "SugarSS"
+    },
+    {
+        "urlParam": "supercollider",
+        "name": "SuperCollider"
+    },
+    {
+        "urlParam": "svg",
+        "name": "SVG"
+    },
+    {
+        "urlParam": "swift",
+        "name": "Swift"
+    },
+    {
+        "urlParam": "systemverilog",
+        "name": "SystemVerilog"
+    },
+    {
+        "urlParam": "tcl",
+        "name": "Tcl"
+    },
+    {
+        "urlParam": "tcsh",
+        "name": "Tcsh"
+    },
+    {
+        "urlParam": "tea",
+        "name": "Tea"
+    },
+    {
+        "urlParam": "terra",
+        "name": "Terra"
+    },
+    {
+        "urlParam": "tex",
+        "name": "TeX"
+    },
+    {
+        "urlParam": "text",
+        "name": "Text"
+    },
+    {
+        "urlParam": "textile",
+        "name": "Textile"
+    },
+    {
+        "urlParam": "thrift",
+        "name": "Thrift"
+    },
+    {
+        "urlParam": "ti-program",
+        "name": "TI Program"
+    },
+    {
+        "urlParam": "tla",
+        "name": "TLA"
+    },
+    {
+        "urlParam": "toml",
+        "name": "TOML"
+    },
+    {
+        "urlParam": "turing",
+        "name": "Turing"
+    },
+    {
+        "urlParam": "turtle",
+        "name": "Turtle"
+    },
+    {
+        "urlParam": "twig",
+        "name": "Twig"
+    },
+    {
+        "urlParam": "txl",
+        "name": "TXL"
+    },
+    {
+        "urlParam": "type-language",
+        "name": "Type Language"
+    },
+    {
+        "urlParam": "typescript",
+        "name": "TypeScript"
+    },
+    {
+        "urlParam": "unified-parallel-c",
+        "name": "Unified Parallel C"
+    },
+    {
+        "urlParam": "unity3d-asset",
+        "name": "Unity3D Asset"
+    },
+    {
+        "urlParam": "unix-assembly",
+        "name": "Unix Assembly"
+    },
+    {
+        "urlParam": "uno",
+        "name": "Uno"
+    },
+    {
+        "urlParam": "unrealscript",
+        "name": "UnrealScript"
+    },
+    {
+        "urlParam": "urweb",
+        "name": "UrWeb"
+    },
+    {
+        "urlParam": "vala",
+        "name": "Vala"
+    },
+    {
+        "urlParam": "vcl",
+        "name": "VCL"
+    },
+    {
+        "urlParam": "verilog",
+        "name": "Verilog"
+    },
+    {
+        "urlParam": "vhdl",
+        "name": "VHDL"
+    },
+    {
+        "urlParam": "vim-script",
+        "name": "Vim script"
+    },
+    {
+        "urlParam": "visual-basic",
+        "name": "Visual Basic"
+    },
+    {
+        "urlParam": "volt",
+        "name": "Volt"
+    },
+    {
+        "urlParam": "vue",
+        "name": "Vue"
+    },
+    {
+        "urlParam": "wavefront-material",
+        "name": "Wavefront Material"
+    },
+    {
+        "urlParam": "wavefront-object",
+        "name": "Wavefront Object"
+    },
+    {
+        "urlParam": "wdl",
+        "name": "wdl"
+    },
+    {
+        "urlParam": "web-ontology-language",
+        "name": "Web Ontology Language"
+    },
+    {
+        "urlParam": "webassembly",
+        "name": "WebAssembly"
+    },
+    {
+        "urlParam": "webidl",
+        "name": "WebIDL"
+    },
+    {
+        "urlParam": "wisp",
+        "name": "wisp"
+    },
+    {
+        "urlParam": "world-of-warcraft-addon-data",
+        "name": "World of Warcraft Addon Data"
+    },
+    {
+        "urlParam": "x10",
+        "name": "X10"
+    },
+    {
+        "urlParam": "xbase",
+        "name": "xBase"
+    },
+    {
+        "urlParam": "xc",
+        "name": "XC"
+    },
+    {
+        "urlParam": "xcompose",
+        "name": "XCompose"
+    },
+    {
+        "urlParam": "xml",
+        "name": "XML"
+    },
+    {
+        "urlParam": "xojo",
+        "name": "Xojo"
+    },
+    {
+        "urlParam": "xpages",
+        "name": "XPages"
+    },
+    {
+        "urlParam": "xpm",
+        "name": "XPM"
+    },
+    {
+        "urlParam": "xproc",
+        "name": "XProc"
+    },
+    {
+        "urlParam": "xquery",
+        "name": "XQuery"
+    },
+    {
+        "urlParam": "xs",
+        "name": "XS"
+    },
+    {
+        "urlParam": "xslt",
+        "name": "XSLT"
+    },
+    {
+        "urlParam": "xtend",
+        "name": "Xtend"
+    },
+    {
+        "urlParam": "yacc",
+        "name": "Yacc"
+    },
+    {
+        "urlParam": "yaml",
+        "name": "YAML"
+    },
+    {
+        "urlParam": "yang",
+        "name": "YANG"
+    },
+    {
+        "urlParam": "yara",
+        "name": "YARA"
+    },
+    {
+        "urlParam": "zephir",
+        "name": "Zephir"
+    },
+    {
+        "urlParam": "zimpl",
+        "name": "Zimpl"
+    }
+]
+


### PR DESCRIPTION
the old readme points out to a file which is missing. Only file that talks about supported Languages is the typescript file in language folder.

But if someone wants to just consume the API from non-JS/TS client getting all supported languages will be a pain in the back. So added the JSON conversion of the supported languages with in the repo.